### PR TITLE
docs: fix Configuration.md wiki — correct schema against init.lua

### DIFF
--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -28,8 +28,8 @@ require("swank").setup({
   -- UI settings
   ui = {
     repl = {
-      position = "auto",  -- "auto" | "right" | "bottom" | "float"
-      size     = 0.45,    -- fraction (0–1) or fixed columns/rows
+      position = "auto",  -- "auto" | "left" | "right" | "top" | "bottom" | "float"
+      size     = 0.45,    -- fraction (0 < size <= 1) or fixed columns/rows
     },
     floating = {
       border = "rounded", -- border style for floating windows
@@ -102,16 +102,18 @@ Then connect with `<LocalLeader>cc` (or `<LocalLeader>rr` to start + connect).
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `ui.repl.position` | `string` | `"auto"` | Window placement strategy |
-| `ui.repl.size` | `number` | `0.45` | Width (for `"right"`) or height (for `"bottom"`) as fraction or integer |
+| `ui.repl.size` | `number` | `0.45` | Width (for vertical splits) or height (for horizontal) as fraction `(0 < size <= 1)` or fixed integer |
 
 ### Position values
 
 | Value | Behaviour |
 |-------|-----------|
 | `"auto"` | Picks the best layout at runtime — see [Architecture: REPL adaptive layout](Architecture#repl-adaptive-layout) |
-| `"right"` | Always a vertical split on the right |
-| `"bottom"` | Always a horizontal split below |
-| `"float"` | Always a floating window centred on screen |
+| `"right"` | Vertical split on the right |
+| `"left"` | Vertical split on the left |
+| `"bottom"` | Horizontal split below |
+| `"top"` | Horizontal split above |
+| `"float"` | Floating window centred on screen |
 
 ### Size
 
@@ -125,7 +127,7 @@ Then connect with `<LocalLeader>cc` (or `<LocalLeader>rr` to start + connect).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.floating.border` | `string` | `"rounded"` | Border style: `"rounded"`, `"single"`, `"double"`, `"solid"`, `"none"` |
+| `ui.floating.border` | `string` | `"rounded"` | Any border value accepted by Neovim for `nvim_open_win()` — see `:h nvim_open_win()`. Common values: `"rounded"`, `"single"`, `"double"`, `"solid"`, `"none"` |
 
 ---
 


### PR DESCRIPTION
The Configuration wiki page had the wrong schema throughout, using old flat keys that do not exist in the codebase.

## What was wrong
- `host`, `port` at top level (actual: `server.host`, `server.port`)
- `autostart = false` boolean (actual: `autostart = { enabled, implementation }`)
- `swank_script`, `sbcl_cmd` keys (do not exist)

## What changed
- Full schema block showing all actual defaults
- Correct nested option tables for `server`, `autostart`, `ui.repl`, `ui.floating`
- Autostart clarified: uses ephemeral port, no start file needed
- New: floating border option, contribs table with descriptions
- Examples updated with correct keys; added CCL and manual-connect examples