### PR TITLE
docs: final accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ swank.nvim is a ground-up Lua rewrite targeting full SLIME feature parity, built
 - [x] Arglist autodoc (`CursorHoldI` → echo area)
 - [x] SLDB debugger — floating window, restart/frame/eval-in-frame
 - [x] Object inspector — navigable parts, back/reinspect
-- [x] Cross-reference (xref) → quickfix / direct jump
+- [x] Cross-reference (xref) → picker or quickfix / direct jump for single result
 - [x] Compiler notes → `vim.diagnostic`
 - [x] Trace dialog (SWANK-TRACE-DIALOG)
 - [x] which-key integration
@@ -310,8 +310,8 @@ so the familiar muscle memory works without a Language Server:
 |-----|--------|
 | `gd` | Go to definition (Swank xref) |
 | `K` | Describe / hover (floating popup) |
-| `gr` | Find references → quickfix |
-| `gR` | Find callers → quickfix |
+| `gr` | Find references → picker or quickfix |
+| `gR` | Find callers → picker or quickfix |
 | `<C-k>` | Arglist / signature help (normal + insert) |
 
 ## Documentation

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -107,7 +107,7 @@ Then connect with `<Leader>lc` (or `<Leader>rr` to start + connect).
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `ui.repl.position` | `string` | `"auto"` | Window placement strategy |
-| `ui.repl.size` | `number` | `0.45` | Width (for vertical splits) or height (for horizontal) as fraction `(0 < size <= 1)` or fixed integer |
+| `ui.repl.size` | `number` | `0.45` | Width (for vertical splits) or height (for horizontal) as fraction `(0 < size <= 1)` or fixed columns/rows |
 
 ### Position values
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -41,23 +41,13 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 ```
 
-### 3. Start Swank in your Lisp project
+### 3. Open a Lisp file
 
-```lisp
-;; start-swank.lisp
-(require :swank)
-(swank:create-server :port 4005 :dont-close t)
-```
+Open any `.lisp` or `.cl` file — swank.nvim spawns SBCL and connects
+automatically. The REPL appears as soon as the server is ready.
 
-```sh
-sbcl --load start-swank.lisp
-```
-
-### 4. Connect from Neovim
-
-```
-<Leader>lc  (Connect to Swank server)
-```
+To connect to an already-running Swank server instead (e.g. on a remote host),
+disable autostart and use `<Leader>lc` to connect manually.
 
 ---
 

--- a/docs/wiki/REPL.md
+++ b/docs/wiki/REPL.md
@@ -9,10 +9,10 @@ interactive prompts.
 ## Opening the REPL
 
 The REPL window opens automatically whenever new output arrives from the server.
-You can also open or focus it manually:
+You can also toggle it manually:
 
 ```
-<Leader>ro
+<Leader>rw
 ```
 
 ---
@@ -61,22 +61,15 @@ REPL window.
 
 ---
 
-## Clearing the REPL
-
-```
-<Leader>rc
-```
-
----
-
 ## Switching packages
 
 ```
-<Leader>rp
+<Leader>lp
 ```
 
 Prompts for a package name and tells the Swank server to switch the active
-evaluation context to that package.
+evaluation context to that package. This is a connection-level setting and is
+available from any Lisp buffer, not just the REPL.
 
 ---
 

--- a/docs/wiki/Testing.md
+++ b/docs/wiki/Testing.md
@@ -30,6 +30,12 @@ Run headless — no display, no server needed. Neovim's full Lua API is availabl
 | `transport_spec.lua` | Message framing: `_feed()` with partial frames, multiple frames, split boundaries |
 | `client_spec.lua` | RPC helpers (`_is_symbol_like`, `_plist`), cursor form extraction, callback dispatch |
 | `repl_spec.lua` | REPL adaptive layout logic: `effective_pos`, `resolve_size`, auto-open behaviour |
+| `inspector_spec.lua` | Inspector content rendering: section parsing, action list display |
+| `sldb_spec.lua` | SLDB buffer rendering: frame formatting, restart list display |
+| `trace_spec.lua` | Trace dialog: `parse_entry` logic, `push_entries`/`set_specs` state management |
+| `notes_spec.lua` | Compiler notes / diagnostics helpers: note-to-diagnostic conversion |
+| `xref_spec.lua` | Cross-reference location parsing (`_extract_location`) and quickfix list building (`_refs_to_qflist`) |
+| `init_spec.lua` | Plugin init module: `setup()` option merging, `attach()` autocmd registration |
 
 ### Minimal init
 

--- a/lua/swank/init.lua
+++ b/lua/swank/init.lua
@@ -16,8 +16,8 @@ local default_config = {
   -- UI settings
   ui = {
     repl = {
-      -- "auto"|"right"|"left"|"top"|"bottom"|"float"
-      -- "auto" picks based on editor width: >=120→right, >=80→bottom, else float
+      -- "auto" picks the best layout based on terminal size:
+      -- right split if REPL gets >=80 cols, bottom if >=12 rows, else float
       position = "auto",
       -- fraction of editor width/height (0 < size <= 1) or fixed columns/rows
       size = 0.45,


### PR DESCRIPTION
Fixes all inaccuracies found during a thorough audit of docs against the codebase.

## Changes

**REPL.md** (3 wrong keybindings — hallucinations):
- `<Leader>ro` → `<Leader>rw` (only one REPL keymap exists: toggle)
- Removed "Clearing the REPL" section — no `rc` binding or `M.clear()` exists
- `<Leader>rp` → `<Leader>lp`; reframed as connection-level feature (not REPL-specific)

**Home.md** — Quick start was autostart-hostile:
- Steps 3-4 showed manual server startup as the primary path, contradicting the autostart-first design documented everywhere else
- Replaced with: open a .lisp file, done; manual connect demoted to a note

**README.md** — Stale xref descriptions:
- Feature list: `quickfix / direct jump` → `picker or quickfix / direct jump`
- LSP table: `gr`/`gR` `→ quickfix` → `→ picker or quickfix`

**xref.lua** — Code comment:
- `falls back to Neovim's built-in numbered selector` → `falls back to a quickfix list`

**init.lua** — Code comment:
- Wrong auto-layout thresholds (`>=120→right` etc.) replaced with accurate description matching the actual `resolve_size()` logic in repl.lua

**Testing.md** — Incomplete test file table:
- Was listing 4 of 10 unit test files
- Added all 6 missing: `inspector_spec`, `sldb_spec`, `trace_spec`, `notes_spec`, `xref_spec`, `init_spec`

**Configuration.md** — Minor:
- `size` description: `fixed integer` → `fixed columns/rows`