### PR TITLE
fix: defer xref picker jump to avoid Telescope cursor-restore race

### DIFF
--- a/lua/swank/ui/xref.lua
+++ b/lua/swank/ui/xref.lua
@@ -104,7 +104,9 @@ function M.show(result, kind)
       prompt      = "swank: " .. kind,
       format_item = function(e) return e.text .. "  " .. e.filename .. ":" .. e.lnum end,
     }, function(choice)
-      if choice then jump_to(choice) end
+      if choice then
+        vim.schedule(function() jump_to(choice) end)
+      end
     end)
   else
     vim.fn.setqflist({}, "r", { title = "swank: " .. kind, items = entries })


### PR DESCRIPTION
## Problem

When `vim.ui.select` (Telescope, Snacks, Dressing, etc.) calls our selection callback, the picker hasn't fully closed yet. Calling `vim.cmd('edit')` synchronously at that point changes the original window's buffer. Telescope's cleanup then tries to restore its previous cursor position in a buffer whose line count is now different:

```
vim.schedule callback: ...telescope.nvim/lua/telescope/pickers.lua:1466:
Invalid cursor line: out of range
```

## Fix

Wrap the `jump_to()` call inside the `vim.ui.select` callback with `vim.schedule()` so it defers until after the picker has fully closed and restored state. The existing inner `vim.schedule` in `jump_to` itself already handles the cursor-after-buffer-load timing — this outer schedule handles the picker-closure timing.

## Tests

All 81 existing tests pass.