### PR TITLE
fix: double-schedule xref picker jump to outlast Telescope cleanup

### DIFF
--- a/lua/swank/ui/xref.lua
+++ b/lua/swank/ui/xref.lua
@@ -105,7 +105,13 @@ function M.show(result, kind)
       format_item = function(e) return e.text .. "  " .. e.filename .. ":" .. e.lnum end,
     }, function(choice)
       if choice then
-        vim.schedule(function() jump_to(choice) end)
+        -- Double-schedule: our first vim.schedule fires before Telescope queues
+        -- its own cursor-restore cleanup. The inner schedule runs after that
+        -- cleanup, so the buffer swap happens after Telescope has finished
+        -- restoring state (avoiding "Invalid cursor line: out of range").
+        vim.schedule(function()
+          vim.schedule(function() jump_to(choice) end)
+        end)
       end
     end)
   else


### PR DESCRIPTION
## Root cause

Single `vim.schedule` was insufficient. When our `vim.ui.select` callback calls `vim.schedule(jump)`, that callback is queued **before** Telescope gets to schedule its own cursor-restore cleanup. So the order was:

1. Our jump fires → `vim.cmd('edit newfile')` → buffer changes in original window
2. Telescope's cleanup fires → tries to restore cursor to old line in new buffer → **`Invalid cursor line: out of range`**

## Fix

Double-schedule the jump so it lands *after* Telescope's cleanup:

1. `outer vim.schedule` fires (before Telescope queues cleanup)
2. `inner vim.schedule` is now queued **after** Telescope's cleanup
3. Telescope cleanup fires → buffer unchanged → ✅
4. Inner jump fires → buffer swap happens safely → ✅

## Tests

All 81 tests pass.